### PR TITLE
Fix log file location determination

### DIFF
--- a/luaoptions-lib.lua
+++ b/luaoptions-lib.lua
@@ -224,7 +224,7 @@ function tex_engine:__call()
     Defines the properties extracted from the first line of jobname.log.
 --]]
     local f = io.open(kpse.find_file(tex.jobname..'.log'))
-    if not f then return end
+    if not f then return {} end
     self.engine, self.engine_version, self.dist, self.dist_version, self.format, self.format_version =
         f:read():match(
             'This is ([^,]*), Version ([^%(]*) %(([^%)]*) ([^%)]*)%)%s+%(format=([^%)]*) ([^)]*)%)'

--- a/luaoptions-lib.lua
+++ b/luaoptions-lib.lua
@@ -223,7 +223,7 @@ function tex_engine:__call()
 --[[
     Defines the properties extracted from the first line of jobname.log.
 --]]
-    local f = io.open(tex.jobname..'.log')
+    local f = io.open(kpse.find_file(tex.jobname..'.log'))
     if not f then return end
     self.engine, self.engine_version, self.dist, self.dist_version, self.format, self.format_version =
         f:read():match(


### PR DESCRIPTION
If having an alternative output directory, the `tex_engine` logfile search will fail.
Using `kpse.find_file` solves the matter, honoring the `TEXMFOUTPUT` variable.

Don't know if `kpse` is available in every situation though.
Solves #6 