### PR TITLE
Fix trailing space in \setluaoption

### DIFF
--- a/luaoptions.sty
+++ b/luaoptions.sty
@@ -23,7 +23,7 @@
       '\luatexluaescapestring{#1}',
       '\luatexluaescapestring{#2}',
       '\luatexluaescapestring{#3}')
-  }
+  }%
 }
 
 % Use an option and directly write it to LaTeX


### PR DESCRIPTION
Equivalent to 2b8786c7 which fixed a similar error in `\useluaoption`